### PR TITLE
fixed carbon-cache init script permissions

### DIFF
--- a/roles/graphite/tasks/main.yml
+++ b/roles/graphite/tasks/main.yml
@@ -32,7 +32,7 @@
 
 
 - name: Configure carbon init.d script
-  copy: src=etc/init.d/carbon-cache dest=/etc/init.d/carbon-cache
+  copy: src=etc/init.d/carbon-cache dest=/etc/init.d/carbon-cache mode=0755
 
 
 - name: Generate random secret key


### PR DESCRIPTION
Set the correct permissions on the carbon-cache init scripts.
