### PR TITLE
Ubuntu Trusty Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,14 @@ Simply clone this repo and make sure you have Vagrant + Virtual Box installed an
   2. visit http://192.168.111.222/
   3. :-) 
 
-Vagrant is using Ubuntu 13.04 Raring Ringtail for it's OS.
+Vagrant is using Ubuntu 14.04 Trusty Tahr for it's OS.
 
 
 ### Digital Ocean
 I've tested this playbook with Digital Ocean VM's with a few different flavor of OS's.
 
-  * CentOS 6.5  
-  * Ubuntu 12.04 Precise Pangolin
-  * Ubuntu 13.04 Raring Ringtail
+  * CentOS 6.5
+  * Ubuntu 14.04 Trusty Tahr
 
 ### AWS EC2
   * Amazon Linux
@@ -71,13 +70,6 @@ Known Issues
 ------------
 * If you are seeing "DatabaseError: database is locked" in your graphite logs, restarting apache may fix the issue for you. 
 * SELinux needs to be disabled
-
-
-Known Issues
-------------
-* If you are seeing "DatabaseError: database is locked" in your graphite logs, restarting apache may fix the issue for you. 
-
-
 
 
 Resources

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,8 +6,8 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "ubuntu-13.04"
-  config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/raring/current/raring-server-cloudimg-amd64-vagrant-disk1.box"
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.box_url = "https://vagrantcloud.com/ubuntu/boxes/trusty64/versions/1/providers/virtualbox.box"
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,15 +4,14 @@ galaxy_info:
   description: Graphite - Scalable Realtime Graphing
   company: Drewl
   license: MIT
-  min_ansible_version: 1.3
+  min_ansible_version: 1.7.2
   platforms:
   - name: EL
     versions:
     - 6
   - name: Ubuntu
     versions:
-    - precise
-    - raring 
+    - trusty
   categories:
   - monitoring
 dependencies: []

--- a/roles/apache/vars/Debian.yml
+++ b/roles/apache/vars/Debian.yml
@@ -2,7 +2,7 @@
 
 apache_user: www-data
 apache_service: apache2
-apache_vhost_dest: /etc/apache2/sites-available
+apache_vhost_dest: /etc/apache2/sites-enabled
 apache_pkgs:
   - apache2-mpm-worker
   - libapache2-mod-wsgi

--- a/roles/graphite/tasks/main.yml
+++ b/roles/graphite/tasks/main.yml
@@ -33,6 +33,13 @@
     - Reload apache
 
 
+- name: Remove the default apache vhost
+  file: "path={{ apache_vhost_dest }}/000-default.conf state=absent"
+  notify:
+    - Reload apache
+  when: ansible_os_family == 'Debian'
+
+
 - name: Configure Graphite webapp
   template: src=opt/graphite/webapp/graphite/local_settings.py.j2
     dest=/opt/graphite/webapp/graphite/local_settings.py mode=0644

--- a/roles/graphite/templates/etc/apache/graphite.conf.j2
+++ b/roles/graphite/templates/etc/apache/graphite.conf.j2
@@ -27,7 +27,10 @@ Listen {{ graphite_apache_port }}
 
         Alias /content/ /opt/graphite/webapp/content/
         <Location "/content/">
-                SetHandler None
+          {% if ansible_os_family == 'Debian' %}
+            Require all granted
+          {% endif %}
+            SetHandler None
         </Location>
 
         # XXX In order for the django admin site media to work you
@@ -40,8 +43,11 @@ Listen {{ graphite_apache_port }}
         # The graphite.wsgi file has to be accessible by apache. It won't
         # be visible to clients because of the DocumentRoot though.
         <Directory /opt/graphite/conf/>
-                Order deny,allow
-                Allow from all
+          {% if ansible_os_family == 'Debian' %}
+            Require all granted
+          {% else %}
+            Order deny,allow
+            Allow from all
+          {% endif %}
         </Directory>
-
 </VirtualHost>

--- a/roles/graphite/vars/Debian.yml
+++ b/roles/graphite/vars/Debian.yml
@@ -1,7 +1,7 @@
 ---
 
 graphite_apache_wsgi_socket_prefix: /var/run/apache2/wsgi
-graphite_apache_vhost_name: default
+graphite_apache_vhost_name: graphite.conf
 
 graphite_pkgs:
   - python-dev


### PR DESCRIPTION
- Drop support for previous versions of Ubuntu
- Upgrade Vagrant image to Trusty

fixes #19 
