### PR TITLE
Remove box.url - it is not needed and not valid

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,6 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "ubuntu/trusty64"
-  config.vm.box_url = "https://vagrantcloud.com/ubuntu/boxes/trusty64/versions/1/providers/virtualbox.box"
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,


### PR DESCRIPTION
`vagrant up` failed when the URL was there with "The requested URL returned error: 404 Not Found". If the URL is removed, vagrant will find the box using its Atlas name, which works.