### PR TITLE
uncomment bitmap-fonts package

### DIFF
--- a/roles/graphite/vars/RedHat.yml
+++ b/roles/graphite/vars/RedHat.yml
@@ -8,5 +8,5 @@ graphite_pkgs:
   - python-sqlite2
   - pycairo
   - libfontenc
-  #- bitmap-fonts
+  - bitmap-fonts
   #- bitmap 


### PR DESCRIPTION
Graph rendering via the web UI fails if this package isn't installed on a CentOS/RH box.
