### PR TITLE
Fix sqlite permissions; Fix PIP bug

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+allow_world_readable_tmpfiles=True

--- a/roles/graphite/tasks/main.yml
+++ b/roles/graphite/tasks/main.yml
@@ -21,7 +21,9 @@
 
 
 - name: Install Graphite from PIP
-  pip: requirements=/tmp/requirements.txt
+  pip:
+    requirements: /tmp/requirements.txt
+    extra_args: "--no-binary=:all:"
   environment:
     PYTHONPATH: "/opt/graphite/lib:/opt/graphite/webapp"
 

--- a/roles/graphite/tasks/main.yml
+++ b/roles/graphite/tasks/main.yml
@@ -16,7 +16,7 @@
   when: ansible_os_family == 'Debian'
 
 
-- name: Create PIP requirements file 
+- name: Create PIP requirements file
   copy: src=opt/graphite/requirements.txt dest=/tmp/requirements.txt
 
 
@@ -68,9 +68,9 @@
 
 
 - name: Setup sqlitedb
-  command: /usr/bin/python manage.py syncdb --noinput chdir=/opt/graphite/webapp/graphite 
-   creates=/opt/graphite/storage/graphite.db
+  command: /usr/bin/python manage.py syncdb --noinput chdir=/opt/graphite/webapp/graphite creates=/opt/graphite/storage/graphite.db
   register: sqlite_setup
+  become_user: "{{ apache_user }}"
 
 
 - name: Wait for sqlitedb to be setup


### PR DESCRIPTION
Two commits:

1. The sqlite permissions should be the same as the graphite/apache process.
2. Fix Graphite installation directory creation. There is a bug with pip and the way the Graphite package is setup that causes webapp directory not to be created.

issues #22 #26 #30 should be fixed as part of this PR. 