### PR TITLE
Fix ordering of storage-schemas

### DIFF
--- a/roles/graphite/templates/opt/graphite/conf/storage-schemas.conf.j2
+++ b/roles/graphite/templates/opt/graphite/conf/storage-schemas.conf.j2
@@ -11,11 +11,10 @@
 pattern = ^carbon\.
 retentions = 60:90d
 
-[default_1min_for_90day]
-pattern = .*
-retentions = 60s:90d
-
-
 [statsd]
 pattern = ^stats.*
 retentions = 10s:6h,1min:7d,10min:5y
+
+[default_1min_for_90day]
+pattern = .*
+retentions = 60s:90d


### PR DESCRIPTION
Storage schemas are read in order, so the default pattern *always* matches, ignoring the statsd one! This just re-orders the patterns so the catch-all default one is at the end.